### PR TITLE
fix: Incorrect region caused volume mount failed

### DIFF
--- a/.ebextensions/00_setup.config
+++ b/.ebextensions/00_setup.config
@@ -7,7 +7,7 @@ commands:
     command: |
       TOKEN=`curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
       INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
-      aws ec2 attach-volume --region us-west-2 --volume-id $VOLUME_ID --instance-id $INSTANCE_ID --device /dev/sdh
+      aws ec2 attach-volume --region ap-south-1 --volume-id $VOLUME_ID --instance-id $INSTANCE_ID --device /dev/sdh
     ignoreErrors: true
   03wait:
     command: sleep 10


### PR DESCRIPTION
Fix: envelope buffer capacity exceeder in sentry.

To get the correct mapping for storing relay sessions
